### PR TITLE
Correct typo of loggers.uvicorn.error

### DIFF
--- a/logging.yaml.example
+++ b/logging.yaml.example
@@ -38,7 +38,7 @@ loggers:
     level: "INFO"
     propagate: false
   uvicorn.error:
-    level": "INFO"
+    level: "INFO"
   uvicorn.access:
     handlers: ["access"]
     level: "INFO"


### PR DESCRIPTION
Found this typo in the logging.yaml.example file (loggers.uvicorn.error)

Took the liberty to correct the typo

Old:
![image](https://github.com/user-attachments/assets/dae2dce7-6bfe-4984-8ba1-266269881276)
