### PR TITLE
Add new dependency and step in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### For development
 
-1.  Install the supported version of Python, Virtualenv, Git and Poetry on your Fedora Linux installation.
+1.  Install the supported version of Python, Virtualenv, Git, Poetry and krb5-devel package on your Fedora Linux installation.
     ```
     $ sudo dnf install python3
     ```
@@ -16,6 +16,9 @@
     ```
     ```
     $ sudo dnf install poetry
+    ```
+    ```
+    $ sudo dnf install krb5-devel
     ```
 
 2.  Clone the repository to your local storage and make it your present working directory.
@@ -67,7 +70,11 @@
     ```
     (venv) $ nano config
     ```
-4.  Start the application with the `--help` flag to understand how the application command line works.
+4.  Modify `.bashrc` file to export W2FM_CONFIG.
+    ```
+    export W2FM_CONFIG=/home/vagrant/webhook-to-fedora-messaging/config
+    ```
+5.  Start the application with the `--help` flag to understand how the application command line works.
     ```
     (venv) $ w2fm --help
     ```
@@ -83,7 +90,7 @@
     Commands:
       setup  Setup the database schema in the specified environment
     ```
-5.  While pointing towards the edited config file, run the `setup` command to initialize the database.
+6.  While pointing towards the edited config file, run the `setup` command to initialize the database.
     ```
     (venv) $ w2fm --conf config setup
     ```
@@ -91,12 +98,12 @@
     ```
     The database has been created
     ```
-6.  Note that the same command can be used to upgrade and downgrade through database schema revisions.
-7.  Once the database is created, run the following command to invoke the service application.
+7.  Note that the same command can be used to upgrade and downgrade through database schema revisions.
+8.  Once the database is created, run the following command to invoke the service application.
     ```
     $ (venv) uvicorn \
                --factory "webhook_to_fedora_messaging.main:create_app" \
-               --log-config logging.yaml
+               --log-config logging.yaml \
                --host 0.0.0.0 \
                --port 8080 \
                --workers 4
@@ -119,7 +126,7 @@
     [W2FM] [2024-08-14 01:56:49 +0530] [INFO] Application startup complete.
     ```
     This command will make `4 workers` processes of the service available on `all interfaces` and on `port 8080`, while logging according to the configuration available in the newly created `logging.yaml` file.
-8.  To stop the service application processes, invoke a keyboard interrupt by pressing `Ctrl` + `C`.
+9.  To stop the service application processes, invoke a keyboard interrupt by pressing `Ctrl` + `C`.
     ```
     Ctrl + C
     ```
@@ -153,7 +160,7 @@
     [W2FM] [2024-08-14 01:58:43 +0530] [INFO] Waiting for child process [11081]
     [W2FM] [2024-08-14 01:58:43 +0530] [INFO] Stopping parent process [11076]
     ```
-9.  For more utility options on running the service, start `uvicorn` with the `--help` flag.
+10.  For more utility options on running the service, start `uvicorn` with the `--help` flag.
     ```
     (venv) $ uvicorn --help
     ```
@@ -170,7 +177,7 @@
       --fd INTEGER                    Bind to socket from this file descriptor.
     ...
     ```
-10. Deactivate the virtual environment by running the following command.
+11. Deactivate the virtual environment by running the following command.
     ```
     (venv) $ deactivate
     ```


### PR DESCRIPTION
Took the liberty to update `README.md` for setting up and running the project locally

- Add dependency for `krb5-devel` package
After installing `krb5-devel` faced no issues while installing the rest of the dependencies
```
sdglitched@fedora:~/webhook-to-fedora-messaging$ source venv-test/bin/activate
(venv-test) sdglitched@fedora:~/webhook-to-fedora-messaging$ poetry check
All set!
(venv-test) sdglitched@fedora:~/webhook-to-fedora-messaging$ poetry install
Installing dependencies from lock file

Package operations: 113 installs, 0 updates, 0 removals

  - Installing attrs (24.2.0)
  - Installing idna (3.10)
  - Installing pycparser (2.22)
  - Installing rpds-py (0.21.0)
  - Installing setuptools (75.3.0)
  - Installing automat (24.8.1)
  - Installing cffi (1.17.1)
  - Installing hyperlink (21.0.0)
  - Installing constantly (23.10.4)
  - Installing incremental (24.7.2)
  - Installing pyasn1 (0.6.1)
  - Installing referencing (0.35.1)
  - Installing typing-extensions (4.12.2)
  - Installing zope-interface (7.1.1)
  - Installing certifi (2024.8.30)
  - Installing jsonschema-specifications (2024.10.1)
  - Installing markupsafe (3.0.2)
  - Installing pyasn1-modules (0.4.1)
  - Installing sniffio (1.3.1)
  - Installing twisted (24.10.0)
  - Installing charset-normalizer (3.4.0)
  - Installing cryptography (43.0.3)
  - Installing h11 (0.14.0)
  - Installing mdurl (0.1.2)
  - Installing urllib3 (2.2.3)
  - Installing wrapt (1.16.0)
  - Installing alabaster (1.0.0)
  - Installing anyio (4.6.2.post1)
  - Installing blinker (1.9.0)
  - Installing distlib (0.3.9)
  - Installing docutils (0.21.2)
  - Installing click (8.1.7)
  - Installing decorator (5.1.1)
  - Installing annotated-types (0.7.0)
  - Installing babel (2.16.0)
  - Installing crochet (2.1.1)
  - Installing filelock (3.16.1)
  - Installing httpcore (1.0.6)
  - Installing imagesize (1.4.1)
  - Installing iniconfig (2.0.0)
  - Installing jinja2 (3.1.4)
  - Installing jsonschema (4.23.0)
  - Installing mako (1.3.6)
  - Installing markdown-it-py (3.0.0)
  - Installing packaging (24.2)
  - Installing pika (1.3.2)
  - Installing platformdirs (4.3.6)
  - Installing pluggy (1.5.0)
  - Installing pydantic-core (2.23.4)
  - Installing pygments (2.18.0)
  - Installing pyopenssl (24.2.1)
  - Installing requests (2.32.3)
  - Installing service-identity (24.2.0)
  - Installing six (1.16.0)
  - Installing snowballstemmer (2.2.0)
  - Installing sphinxcontrib-applehelp (2.0.0)
  - Installing sphinxcontrib-devhelp (2.0.0)
  - Installing sphinxcontrib-htmlhelp (2.1.0)
  - Installing sphinxcontrib-jsmath (1.0.1)
  - Installing sphinxcontrib-qthelp (2.0.0)
  - Installing sphinxcontrib-serializinghtml (2.0.0)
  - Installing sqlalchemy (2.0.36)
  - Installing tomli (2.0.2)
  - Installing alembic (1.14.0)
  - Installing chardet (5.2.0)
  - Installing httptools (0.6.4)
  - Installing identify (2.6.2)
  - Installing coverage (7.6.4)
  - Installing cfgv (3.4.0)
  - Installing gssapi (1.9.0)
  - Installing mdit-py-plugins (0.4.2)
  - Installing fedora-messaging (3.6.0)
  - Installing httpx (0.27.2)
  - Installing mypy-extensions (1.0.0)
  - Installing nodeenv (1.9.1)
  - Installing pathspec (0.12.1)
  - Installing pockets (0.9.1)
  - Installing pydantic (2.9.2)
  - Installing pyjwt (2.9.0)
  - Installing pytest (8.3.3)
  - Installing python-dotenv (1.0.1)
  - Installing pyyaml (6.0.2)
  - Installing semantic-version (2.10.0)
  - Installing sphinx (8.1.3)
  - Installing starlette (0.41.2)
  - Installing toml (0.10.2)
  - Installing uritemplate (4.1.1)
  - Installing uvloop (0.21.0)
  - Installing virtualenv (20.27.1)
  - Installing watchfiles (0.24.0)
  - Installing websockets (14.0)
  - Installing fastapi (0.115.4)
  - Installing httpx-gssapi (0.3.1)
  - Installing authlib (1.3.2)
  - Installing backoff (2.2.1)
  - Installing black (24.10.0)
  - Installing cashews (7.3.2)
  - Installing diff-cover (9.2.0)
  - Installing gidgethub (5.3.0)
  - Installing greenlet (3.1.1)
  - Installing aiosqlite (0.20.0)
  - Installing itsdangerous (2.2.0)
  - Installing liccheck (0.9.2)
  - Installing myst-parser (4.0.0)
  - Installing pre-commit (4.0.1)
  - Installing pydantic-settings (2.6.1)
  - Installing pytest-asyncio (0.24.0)
  - Installing pytest-cov (6.0.0)
  - Installing ruff (0.7.3)
  - Installing sphinxcontrib-napoleon (0.7)
  - Installing sqlalchemy-helpers (1.0.1)
  - Installing uvicorn (0.32.0)
  - Installing webhook-to-fedora-messaging-messages (1.0.1)

Installing the current project: webhook-to-fedora-messaging (0.1.0)
(venv-test) sdglitched@fedora:~/webhook-to-fedora-messaging$ 
```

- Add new Step for modifying `.bashrc` file to export W2FM_CONFIG
After exporting the config variable `W2FM_CONFIG` endpoint `/api /v1 /users /search /{username}` seems to be working as intended
![image](https://github.com/user-attachments/assets/3ac3fdce-b9bd-4e5b-9516-2b51f73bd08d)

This PR should fix the issue #109. 