### PR TITLE
Add Python 3.13 in the testing matrix for GitHub Actions and Tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
         pyver:
           - py311
           - py312
+          - py313
 
 
   # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = checks,licenses,docs,py{311,312}
+envlist = checks,licenses,docs,py{311,312,313}
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
The changes in this PR fix: #172 

<hr>

Added Python 3.13 in the testing matrix for GitHub Actions and Tox.