### PR TITLE
Refactor the parsers

### DIFF
--- a/webhook_to_fedora_messaging/endpoints/parser/__init__.py
+++ b/webhook_to_fedora_messaging/endpoints/parser/__init__.py
@@ -4,8 +4,8 @@ from fedora_messaging.api import Message
 from starlette.requests import Request
 
 from ...models import Service
-from .forgejo import forgejo_parser
-from .github import github_parser
+from .forgejo import ForgejoParser
+from .github import GitHubParser
 
 
 logger = logging.getLogger(__name__)
@@ -13,16 +13,16 @@ logger = logging.getLogger(__name__)
 
 async def parser(service: Service, request: Request) -> Message:
     parsers = {
-        "github": github_parser,
-        "forgejo": forgejo_parser,
+        "github": GitHubParser,
+        "forgejo": ForgejoParser,
     }
 
-    parser_func = parsers.get(service.type.lower())
-    if not parser_func:
+    parser = parsers.get(service.type.lower())
+    if not parser:
         raise ValueError(f"Unsupported service: {service.type}")
 
     try:
-        return await parser_func(service.token, request)
+        return await parser(service.token, request).parse()
     except Exception:
         logger.exception("Message could not be parsed")
         raise

--- a/webhook_to_fedora_messaging/endpoints/parser/base.py
+++ b/webhook_to_fedora_messaging/endpoints/parser/base.py
@@ -1,10 +1,12 @@
+import hashlib
+import hmac
 import json
-from collections.abc import Awaitable
-from functools import wraps
-from typing import Any, Callable, TypeAlias
+from typing import Any, TypeAlias
 
 from fedora_messaging.api import Message
 from starlette.requests import Request
+
+from ...exceptions import SignatureMatchError
 
 
 HeadersDict: TypeAlias = dict[str, str]
@@ -12,16 +14,49 @@ Body: TypeAlias = dict[str, Any]
 BodyData: TypeAlias = bytes
 
 
-def initialize_parser(
-    function: Callable[[str, HeadersDict, Body, BodyData], Awaitable[Message]],
-) -> Callable[[str, Request], Awaitable[Message]]:
-    @wraps(function)
-    async def verify_before(token: str, request: Request) -> Message:
-        headers = {k.lower(): v for k, v in request.headers.items()}
+class BaseParser:
+
+    message_class: type[Message] = Message
+
+    def __init__(self, token: str, request: Request):
+        self._token = token
+        self._request = request
+
+    async def get_headers_and_data(self) -> tuple[HeadersDict, bytes]:
+        headers = {k.lower(): v for k, v in self._request.headers.items()}
         if "x-hub-signature-256" not in headers:
             raise KeyError("Signature not found")
-        data = await request.body()
-        body = json.loads(data.decode("utf-8"))
-        return await function(token, headers, body, data)
+        data = await self._request.body()
+        return headers, data
 
-    return verify_before
+    async def validate(self, headers: HeadersDict, data: bytes) -> None:
+        raise NotImplementedError
+
+    def _get_topic(self, headers: HeadersDict, body: Body) -> str:
+        raise NotImplementedError
+
+    async def _get_agent(self, body: Body) -> str | None: ...
+
+    def _validate_with_sig_header(self, sig_header: str, data: BodyData) -> None:
+        """
+        Verify the payload by validating its signature.
+        """
+        algorithm, signature = sig_header.split("=", 1)
+        try:
+            algo_function = getattr(hashlib, algorithm)
+        except AttributeError as e:
+            raise SignatureMatchError(f"Unsupported algorithm: {algorithm}") from e
+        hash_object = hmac.new(self._token.encode("utf-8"), msg=data, digestmod=algo_function)
+        if not hmac.compare_digest(hash_object.hexdigest(), signature):
+            raise SignatureMatchError("Message signature could not be matched")
+
+    async def parse(self) -> Message:
+        headers, data = await self.get_headers_and_data()
+        if self._token:
+            await self.validate(headers, data)
+        body = json.loads(data.decode("utf-8"))
+        topic = self._get_topic(headers, body)
+        agent = await self._get_agent(body)
+        return self.message_class(
+            topic=topic, body={"body": body, "headers": headers, "agent": agent}
+        )

--- a/webhook_to_fedora_messaging/endpoints/parser/forgejo.py
+++ b/webhook_to_fedora_messaging/endpoints/parser/forgejo.py
@@ -1,49 +1,21 @@
-import hmac
-from collections.abc import Awaitable
-from functools import wraps
-from hashlib import sha256
-from typing import Callable
-
-from fedora_messaging.api import Message
 from webhook_to_fedora_messaging_messages.forgejo import ForgejoMessageV1
 
-from ...endpoints.parser.base import initialize_parser
-from ...exceptions import SignatureMatchError
 from ...fasjson import get_fasjson
-from .base import Body, BodyData, HeadersDict
+from .base import BaseParser, Body, BodyData, HeadersDict
 
 
-def validate_checksum(
-    function: Callable[[HeadersDict, Body], Awaitable[Message]],
-) -> Callable[[str, HeadersDict, Body, BodyData], Awaitable[Message]]:
-    @wraps(function)
-    async def verify_before(
-        token: str, headers: HeadersDict, body: Body, data: BodyData
-    ) -> Message:
+class ForgejoParser(BaseParser):
+
+    message_class = ForgejoMessageV1
+
+    async def validate(self, headers: HeadersDict, data: BodyData) -> None:
         """
-        Verify that the payload was sent from GitHub by validating SHA256.
+        Verify that the payload was sent from ForgeJo by validating SHA256.
         """
-        if token:
-            sign = headers["x-hub-signature-256"]
-            hash_object = hmac.new(token.encode("utf-8"), msg=data, digestmod=sha256)
-            expected = f"sha256={hash_object.hexdigest()}"
-            if not hmac.compare_digest(expected, sign):
-                raise SignatureMatchError("Message signature could not be matched")
-        return await function(headers, body)
+        self._validate_with_sig_header(headers["x-hub-signature-256"], data)
 
-    return verify_before
+    def _get_topic(self, headers: HeadersDict, body: Body) -> str:
+        return f"forgejo.{headers['x-forgejo-event']}"
 
-
-@initialize_parser
-@validate_checksum
-async def forgejo_parser(headers: HeadersDict, body: Body) -> ForgejoMessageV1:
-    """
-    Convert request objects into desired Fedora Messaging format
-    """
-    topic = f"forgejo.{headers['x-forgejo-event']}"
-    username = body["sender"]["login"]
-    # If the ForgeJo instance is Fedora's, we know it's authenticated with FAS,
-    # just use the username for the agent. Otherwise, just use None,
-    # as we can't store every instance's username mapping in IPA.
-    agent = await get_fasjson().get_username_from_forgejo(username)
-    return ForgejoMessageV1(topic=topic, body={"body": body, "headers": headers, "agent": agent})
+    async def _get_agent(self, body: Body) -> str | None:
+        return await get_fasjson().get_username_from_forgejo(body["sender"]["login"])

--- a/webhook_to_fedora_messaging/endpoints/parser/github.py
+++ b/webhook_to_fedora_messaging/endpoints/parser/github.py
@@ -1,45 +1,21 @@
-import hmac
-from collections.abc import Awaitable
-from functools import wraps
-from hashlib import sha256
-from typing import Callable
-
-from fedora_messaging.api import Message
 from webhook_to_fedora_messaging_messages.github import GitHubMessageV1
 
-from ...endpoints.parser.base import initialize_parser
-from ...exceptions import SignatureMatchError
 from ...fasjson import get_fasjson
-from .base import Body, BodyData, HeadersDict
+from .base import BaseParser, Body, BodyData, HeadersDict
 
 
-def validate_checksum(
-    function: Callable[[HeadersDict, Body], Awaitable[Message]],
-) -> Callable[[str, HeadersDict, Body, BodyData], Awaitable[Message]]:
-    @wraps(function)
-    async def verify_before(
-        token: str, headers: HeadersDict, body: Body, data: BodyData
-    ) -> Message:
+class GitHubParser(BaseParser):
+
+    message_class = GitHubMessageV1
+
+    async def validate(self, headers: HeadersDict, data: BodyData) -> None:
         """
         Verify that the payload was sent from GitHub by validating SHA256.
         """
-        if token:
-            sign = headers["x-hub-signature-256"]
-            hash_object = hmac.new(token.encode("utf-8"), msg=data, digestmod=sha256)
-            expected = f"sha256={hash_object.hexdigest()}"
-            if not hmac.compare_digest(expected, sign):
-                raise SignatureMatchError("Message signature could not be matched")
-        return await function(headers, body)
+        self._validate_with_sig_header(headers["x-hub-signature-256"], data)
 
-    return verify_before
+    def _get_topic(self, headers: HeadersDict, body: Body) -> str:
+        return f"github.{headers['x-github-event']}"
 
-
-@initialize_parser
-@validate_checksum
-async def github_parser(headers: HeadersDict, body: Body) -> GitHubMessageV1:
-    """
-    Convert request objects into desired Fedora Messaging format
-    """
-    topic = f"github.{headers['x-github-event']}"
-    agent = await get_fasjson().get_username_from_github(body["sender"]["login"])
-    return GitHubMessageV1(topic=topic, body={"body": body, "headers": headers, "agent": agent})
+    async def _get_agent(self, body: Body) -> str | None:
+        return await get_fasjson().get_username_from_github(body["sender"]["login"])


### PR DESCRIPTION
This is a refactor of the functional-programming-based parsers into an object-oriented model.
The plus side is that the decorators are no longer changing the signature of the functions.
Instead, there is a common entry point, the `parse()` method, which does all the common steps.
The subclassed parsers are free to implement their specificities in the appropriate methods.
A second advantage is that it will be trivial to implement a validation-less parser, as required by GitLab (the `validate()` method can just `pass`).

What do you think @gridhead ?