### PR TITLE
Fixed README.md text (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
     [W2FM] [2024-08-14 01:58:43 +0530] [INFO] Waiting for child process [11081]
     [W2FM] [2024-08-14 01:58:43 +0530] [INFO] Stopping parent process [11076]
     ```
-10.  For more utility options on running the service, start `uvicorn` with the `--help` flag.
+10. For more utility options on running the service, start `uvicorn` with the `--help` flag.
     ```
     (venv) $ uvicorn --help
     ```


### PR DESCRIPTION
Found extra space on line 160, after the "10. ", which messes up the spacing. 

[image](https://github.com/user-attachments/assets/e9b71dc2-cc10-4815-837c-7c0d076a4695)
