### PR TITLE
Correct image paths in documentation markdown files

### DIFF
--- a/frontend/src/assets/docs/fogo.md
+++ b/frontend/src/assets/docs/fogo.md
@@ -5,22 +5,22 @@ Forgejo repository to be conveyed to the Fedora Messaging bus.
    a unique name and an appropriate description.
 
 2. Navigate to the project repository on **Forgejo**.
-   ![](../../../public/imgs/fogo/1.png)
+   ![](/imgs/fogo/1.png)
 
 3. On the **Settings** page, navigate to the **Webhooks** section.
-   ![](../../../public/imgs/fogo/2.png)
+   ![](/imgs/fogo/2.png)
 
 4. Click on the **Add webhook** button to open the combobox.
-   ![](../../../public/imgs/fogo/3.png)
+   ![](/imgs/fogo/3.png)
 
 5. Select the **Forgejo** option there to begin.
-   ![](../../../public/imgs/fogo/4.png)
+   ![](/imgs/fogo/4.png)
 
 6. Fill the information accurately from the created webhook bind.
-   ![](../../../public/imgs/fogo/5.png)
+   ![](/imgs/fogo/5.png)
 
 7. After saving, the webhook bind should be enabled.
-   ![](../../../public/imgs/fogo/6.png)
+   ![](/imgs/fogo/6.png)
 
 8. Perform one of the following actions for triggering the events.
    1. Push (Events catalogued under the [`org.fedoraproject.prod.forgejo.push`](https://apps.fedoraproject.org/datagrepper/v2/search?topic=org.fedoraproject.prod.forgejo.push) topic)

--- a/frontend/src/assets/docs/gthb.md
+++ b/frontend/src/assets/docs/gthb.md
@@ -5,22 +5,22 @@ GitHub repository to be conveyed to the Fedora Messaging bus.
    a unique name and an appropriate description.
 
 2. Navigate to the project repository on **GitHub**.
-   ![](../../../public/imgs/gthb/1.png)
+   ![](/imgs/gthb/1.png)
 
 3. On the **Settings** page, navigate to the **Webhooks** section.
-   ![](../../../public/imgs/gthb/2.png)
+   ![](/imgs/gthb/2.png)
 
 4. Click on the **Add webhook** button to begin.
-   ![](../../../public/imgs/gthb/3.png)
+   ![](/imgs/gthb/3.png)
 
 5. Reauthenticate yourself to **GitHub** if required.
-   ![](../../../public/imgs/gthb/4.png)
+   ![](/imgs/gthb/4.png)
 
 6. Fill the information accurately from the created webhook bind.
-   ![](../../../public/imgs/gthb/5.png)
+   ![](/imgs/gthb/5.png)
 
 7. After saving, the webhook bind should be enabled.
-   ![](../../../public/imgs/gthb/6.png)
+   ![](/imgs/gthb/6.png)
 
 8. Perform one of the following actions for triggering the events.
    1. Push (Events catalogued under the [`org.fedoraproject.prod.github.push`](https://apps.fedoraproject.org/datagrepper/v2/search?topic=org.fedoraproject.prod.github.push) topic)

--- a/frontend/src/assets/docs/gtlb.md
+++ b/frontend/src/assets/docs/gtlb.md
@@ -5,22 +5,22 @@ GitLab repository to be conveyed to the Fedora Messaging bus.
    a unique name and an appropriate description.
 
 2. From the navigation menu, head over to the **Webhooks** page from the **Settings** section.
-   ![](../../../public/imgs/gtlb/1.png)
+   ![](/imgs/gtlb/1.png)
 
 3. Click on the **Add new webhook** button.
-   ![](../../../public/imgs/gtlb/2.png)
+   ![](/imgs/gtlb/2.png)
 
 4. Fill the information accurately from the created webhook bind.
-   ![](../../../public/imgs/gtlb/3.png)
+   ![](/imgs/gtlb/3.png)
 
 5. Select all applicable events for triggering the webhook.
-   ![](../../../public/imgs/gtlb/4.png)
+   ![](/imgs/gtlb/4.png)
 
 6. Click on the **Add webhook** button to save changes.
-   ![](../../../public/imgs/gtlb/5.png)
+   ![](/imgs/gtlb/5.png)
 
 7. After saving, the webhook bind should be enabled.
-   ![](../../../public/imgs/gtlb/6.png)
+   ![](/imgs/gtlb/6.png)
 
 8. Perform one of the following actions for triggering the events.
    1. Push (Events catalogued under the [`org.fedoraproject.prod.gitlab.push`](https://apps.fedoraproject.org/datagrepper/v2/search?topic=org.fedoraproject.prod.gitlab.push) topic)


### PR DESCRIPTION
This PR removes `/public` prefix from image references to align with Vite's public directory serving behaviour where public assets are served at root path.

<img width="1920" height="1048" alt="Screenshot From 2025-08-17 12-36-08" src="https://github.com/user-attachments/assets/18527f47-aea7-4835-ba11-4bd587d0aa38" />
<img width="400" height="110" alt="Screenshot From 2025-08-17 12-36-40" src="https://github.com/user-attachments/assets/7263175e-dea8-4a66-855d-71a7a3be3261" />

Fixes: #228 