### PR TITLE
Remove stray debug console printings

### DIFF
--- a/frontend/src/components/code.jsx
+++ b/frontend/src/components/code.jsx
@@ -18,32 +18,26 @@ import {
 } from "../features/part.jsx";
 
 async function codeUnit(dispatch, uuid) {
+  let data;
   try {
-    let data;
-    try {
-      data = await apiCall({ method: "PUT", path: `/services/${uuid}/regenerate` });
-      console.log("Result:", data);
-    } catch (error) {
-      console.log(error);
-      dispatch(hideReviving());
-      dispatch(hideFlagArea());
-      dispatch(keepFlagHead("Bind regeneration failed"));
-      dispatch(keepFlagBody(`Encountered "${error.toString()}" response during regeneration`));
-      dispatch(showFlagArea());
-      dispatch(failFlagStat());
-      return;
-    } finally {
-      dispatch(keepServices());
-    }
+    data = await apiCall({ method: "PUT", path: `/services/${uuid}/regenerate` });
+  } catch (error) {
     dispatch(hideReviving());
     dispatch(hideFlagArea());
-    dispatch(keepFlagHead(`Bind #${data.uuid} regenerated`));
-    dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+    dispatch(keepFlagHead("Bind regeneration failed"));
+    dispatch(keepFlagBody(`Encountered "${error.toString()}" response during regeneration`));
     dispatch(showFlagArea());
-    dispatch(passFlagStat());
-  } catch (expt) {
-    console.log(expt);
+    dispatch(failFlagStat());
+    return;
+  } finally {
+    dispatch(keepServices());
   }
+  dispatch(hideReviving());
+  dispatch(hideFlagArea());
+  dispatch(keepFlagHead(`Bind #${data.uuid} regenerated`));
+  dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+  dispatch(showFlagArea());
+  dispatch(passFlagStat());
 }
 
 function Reviving() {

--- a/frontend/src/components/edit.jsx
+++ b/frontend/src/components/edit.jsx
@@ -19,41 +19,37 @@ import {
 import DiffCard from "./diff.jsx";
 
 async function editUnit(dispatch, uuid) {
+  let data;
   try {
-    let data;
-    try {
-      data = await apiCall({
-        method: "PUT",
-        path: `/services/${uuid}`,
-        body: {
-          data: {
-            name: document.getElementById(`name-${uuid}`).value,
-            type: document.getElementById(`type-${uuid}`).value,
-            desc: document.getElementById(`desc-${uuid}`).value,
-            username: document.getElementById(`user-${uuid}`).value,
-          },
+    data = await apiCall({
+      method: "PUT",
+      path: `/services/${uuid}`,
+      body: {
+        data: {
+          name: document.getElementById(`name-${uuid}`).value,
+          type: document.getElementById(`type-${uuid}`).value,
+          desc: document.getElementById(`desc-${uuid}`).value,
+          username: document.getElementById(`user-${uuid}`).value,
         },
-      });
-    } catch (error) {
-      dispatch(hideUpdating());
-      dispatch(hideFlagArea());
-      dispatch(keepFlagHead("Bind updating failed"));
-      dispatch(keepFlagBody(`Encountered "${error.toString()}" response during updating`));
-      dispatch(showFlagArea());
-      dispatch(failFlagStat());
-      return;
-    } finally {
-      dispatch(keepServices());
-    }
+      },
+    });
+  } catch (error) {
     dispatch(hideUpdating());
     dispatch(hideFlagArea());
-    dispatch(keepFlagHead(`Bind #${data.uuid} updated`));
-    dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+    dispatch(keepFlagHead("Bind updating failed"));
+    dispatch(keepFlagBody(`Encountered "${error.toString()}" response during updating`));
     dispatch(showFlagArea());
-    dispatch(passFlagStat());
-  } catch (expt) {
-    console.log(expt);
+    dispatch(failFlagStat());
+    return;
+  } finally {
+    dispatch(keepServices());
   }
+  dispatch(hideUpdating());
+  dispatch(hideFlagArea());
+  dispatch(keepFlagHead(`Bind #${data.uuid} updated`));
+  dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+  dispatch(showFlagArea());
+  dispatch(passFlagStat());
 }
 
 function Updating() {

--- a/frontend/src/components/make.jsx
+++ b/frontend/src/components/make.jsx
@@ -18,41 +18,36 @@ import {
 } from "../features/part.jsx";
 
 async function saveUnit(dispatch) {
+  let data;
   try {
-    let data;
-    try {
-      data = await apiCall({
-        method: "POST",
-        path: `/services`,
-        body: {
-          data: {
-            name: document.getElementById("name-make").value.trim(),
-            desc: document.getElementById("desc-make").value.trim(),
-            type: document.getElementById("type-make").value.trim(),
-          },
+    data = await apiCall({
+      method: "POST",
+      path: `/services`,
+      body: {
+        data: {
+          name: document.getElementById("name-make").value.trim(),
+          desc: document.getElementById("desc-make").value.trim(),
+          type: document.getElementById("type-make").value.trim(),
         },
-      });
-      console.log("Result:", data);
-    } catch (error) {
-      dispatch(hideCreation());
-      dispatch(hideFlagArea());
-      dispatch(keepFlagHead("Bind creation failed"));
-      dispatch(keepFlagBody(`Encountered "${error.toString()}" response during creation`));
-      dispatch(showFlagArea());
-      dispatch(failFlagStat());
-      return;
-    } finally {
-      dispatch(keepServices());
-    }
+      },
+    });
+  } catch (error) {
     dispatch(hideCreation());
     dispatch(hideFlagArea());
-    dispatch(keepFlagHead(`Bind #${data.uuid} created`));
-    dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+    dispatch(keepFlagHead("Bind creation failed"));
+    dispatch(keepFlagBody(`Encountered "${error.toString()}" response during creation`));
     dispatch(showFlagArea());
-    dispatch(passFlagStat());
-  } catch (expt) {
-    console.log(expt);
+    dispatch(failFlagStat());
+    return;
+  } finally {
+    dispatch(keepServices());
   }
+  dispatch(hideCreation());
+  dispatch(hideFlagArea());
+  dispatch(keepFlagHead(`Bind #${data.uuid} created`));
+  dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+  dispatch(showFlagArea());
+  dispatch(passFlagStat());
 }
 
 function Creation() {

--- a/frontend/src/components/wipe.jsx
+++ b/frontend/src/components/wipe.jsx
@@ -18,32 +18,27 @@ import {
 } from "../features/part.jsx";
 
 async function wipeUnit(dispatch, uuid) {
+  let data;
   try {
-    let data;
-    try {
-      data = await apiCall({ method: "PUT", path: `/services/${uuid}/revoke` });
-      console.log("Result:", data);
-    } catch (error) {
-      dispatch(keepServices());
-      dispatch(hideRevoking());
-      dispatch(hideFlagArea());
-      dispatch(keepFlagHead("Bind revocation failed"));
-      dispatch(keepFlagBody(`Encountered "${error.toString()}" response during revocation`));
-      dispatch(showFlagArea());
-      dispatch(failFlagStat());
-      return;
-    } finally {
-      dispatch(keepServices());
-    }
+    data = await apiCall({ method: "PUT", path: `/services/${uuid}/revoke` });
+  } catch (error) {
+    dispatch(keepServices());
     dispatch(hideRevoking());
     dispatch(hideFlagArea());
-    dispatch(keepFlagHead(`Bind #${data.uuid} revoked`));
-    dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+    dispatch(keepFlagHead("Bind revocation failed"));
+    dispatch(keepFlagBody(`Encountered "${error.toString()}" response during revocation`));
     dispatch(showFlagArea());
-    dispatch(passFlagStat());
-  } catch (expt) {
-    console.log(expt);
+    dispatch(failFlagStat());
+    return;
+  } finally {
+    dispatch(keepServices());
   }
+  dispatch(hideRevoking());
+  dispatch(hideFlagArea());
+  dispatch(keepFlagHead(`Bind #${data.uuid} revoked`));
+  dispatch(keepFlagBody("Relevant information can be found on the dashboard"));
+  dispatch(showFlagArea());
+  dispatch(passFlagStat());
 }
 
 function Revoking() {

--- a/frontend/src/features/api.js
+++ b/frontend/src/features/api.js
@@ -5,7 +5,6 @@ export async function apiCall({ method, path, body }) {
   if (!userdata || userdata.expired) {
     throw new Error("Unauthenticated", { cause: new Response(null, { status: 401, statusText: "Unauthenticated" }) });
   }
-  console.log(body);
   const resp = await fetch(`${import.meta.env.VITE_API_URL}/api/v1${path}`, {
     method: method,
     headers: {

--- a/frontend/src/features/auth.jsx
+++ b/frontend/src/features/auth.jsx
@@ -19,7 +19,6 @@ const authData = createSlice({
       auth.user = null;
       auth.disp = "https://seccdn.libravatar.org/avatar/40f8d096a3777232204cb3f796c577b7?s=30";
       auth.status = "idle";
-      console.log("WIPED");
     },
   },
   extraReducers: (plan) => {


### PR DESCRIPTION
This PR removes stray debug console printings by removing debug console.log statements and also simplifies the nested try-catch blocks by removing redundant outer catch.

Fixes: #229 